### PR TITLE
Update env_logger to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,19 @@ A logging implementation for `log` which hooks to android log output.
 """
 keywords = ["android", "bindings", "log", "logger"]
 categories = ["api-bindings"]
+edition = "2021"
 
 [features]
 default = ["regex"]
-regex = ["env_logger/regex"]
+regex = ["env_filter/regex"]
 
 [dependencies]
 once_cell = "1.9"
+env_filter = "0.1.0"
+env_logger = "0.11.2"
 
 [dependencies.log]
 version = "0.4"
 
 [dependencies.android_log-sys]
 version = "0.3"
-
-[dependencies.env_logger]
-version = "0.10"
-default-features = false


### PR DESCRIPTION
I've also updated the edition to 2021, because our dependencies have an MSRV of (at least) 1.71 - [env_logger](https://github.com/rust-cli/env_logger/blob/8962096976b0fa9c05b8b5ba5251861d60abf943/Cargo.toml#L8), for example