### PR TITLE
remove once_cell as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ regex = ["env_filter/regex"]
 
 [dependencies]
 env_filter = "0.1.0"
-env_logger = "0.11.2"
 
 [dependencies.log]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ default = ["regex"]
 regex = ["env_filter/regex"]
 
 [dependencies]
-once_cell = "1.9"
 env_filter = "0.1.0"
 env_logger = "0.11.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "android_logger"
-version = "0.13.3"
+version = "0.14.0"
 authors = ["The android_logger Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@ use std::ptr;
 use std::sync::OnceLock;
 
 pub use env_filter::{Builder as FilterBuilder, Filter};
-pub use env_logger::fmt::Formatter;
 
 pub(crate) type FormatFn = Box<dyn Fn(&mut dyn fmt::Write, &Record) -> fmt::Result + Sync + Send>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@
 
 #[cfg(target_os = "android")]
 extern crate android_log_sys as log_ffi;
-use once_cell::sync::OnceCell;
 
 use log::{Level, LevelFilter, Log, Metadata, Record};
 #[cfg(target_os = "android")]
@@ -74,6 +73,7 @@ use std::ffi::{CStr, CString};
 use std::fmt;
 use std::mem::{self, MaybeUninit};
 use std::ptr;
+use std::sync::OnceLock;
 
 pub use env_filter::{Builder as FilterBuilder, Filter};
 pub use env_logger::fmt::Formatter;
@@ -162,14 +162,14 @@ fn android_log(_buf_id: Option<LogId>, _priority: Level, _tag: &CStr, _msg: &CSt
 
 /// Underlying android logger backend
 pub struct AndroidLogger {
-    config: OnceCell<Config>,
+    config: OnceLock<Config>,
 }
 
 impl AndroidLogger {
     /// Create new logger instance from config
     pub fn new(config: Config) -> AndroidLogger {
         AndroidLogger {
-            config: OnceCell::from(config),
+            config: OnceLock::from(config),
         }
     }
 
@@ -178,7 +178,7 @@ impl AndroidLogger {
     }
 }
 
-static ANDROID_LOGGER: OnceCell<AndroidLogger> = OnceCell::new();
+static ANDROID_LOGGER: OnceLock<AndroidLogger> = OnceLock::new();
 
 const LOGGING_TAG_MAX_LEN: usize = 23;
 const LOGGING_MSG_MAX_LEN: usize = 4000;
@@ -187,7 +187,7 @@ impl Default for AndroidLogger {
     /// Create a new logger with default config
     fn default() -> AndroidLogger {
         AndroidLogger {
-            config: OnceCell::from(Config::default()),
+            config: OnceLock::from(Config::default()),
         }
     }
 }


### PR DESCRIPTION
our MSVR at least 1.71.0, and once_cell was merge into std in 1.70.0, so there are no reason to use external one instead of std