### PR TITLE
Fix regex dependencies getting pulled unexpectedly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,12 @@ edition = "2021"
 default = ["regex"]
 regex = ["env_filter/regex"]
 
-[dependencies]
-env_filter = "0.1.0"
-
 [dependencies.log]
 version = "0.4"
 
 [dependencies.android_log-sys]
 version = "0.3"
+
+[dependencies.env_filter]
+version = "0.1"
+default-features = false


### PR DESCRIPTION
Also moved `env_filter` to a separate section for consistency.

Fixes #73 