### PR TITLE
Only provide docs.rs pages for Android targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,16 @@ keywords = ["android", "bindings", "log", "logger"]
 categories = ["api-bindings"]
 edition = "2021"
 
+[package.metadata.docs.rs]
+targets = [
+  "aarch64-linux-android",
+  "arm-linux-androideabi",
+  "armv7-linux-androideabi",
+  "i686-linux-android",
+  "thumbv7neon-linux-androideabi",
+  "x86_64-linux-android",
+]
+
 [features]
 default = ["regex"]
 regex = ["env_filter/regex"]


### PR DESCRIPTION
Fixes #76

Even though a lot of `cfg` make it possible to compile this Android-specific crate on non-Android platforms, only seeing non-Android platforms inside the docs.rs platform dropdown appears a bit strange.

Instead, build the documentation for every Android platform listed at https://doc.rust-lang.org/rustc/platform-support/android.html, which might also result in better intradoc links to specific types provided by `std`.
