### PR TITLE
cargo: Add `os::android-apis` category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = """
 A logging implementation for `log` which hooks to android log output.
 """
 keywords = ["android", "bindings", "log", "logger"]
-categories = ["api-bindings"]
+categories = ["api-bindings", "os::android-apis"]
 edition = "2021"
 
 [features]


### PR DESCRIPTION
Since this crate provides access/interop to an Android-specific (OS) API, use the new `os::android-apis` category that I recently upstreamed at https://github.com/rust-lang/crates.io/pull/8558.  That'll make this crate show up at https://crates.io/categories/os::android-apis going forward.
