### PR TITLE
Prevent truncating log tag name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,8 @@ impl AndroidLogger {
 
 static ANDROID_LOGGER: OnceLock<AndroidLogger> = OnceLock::new();
 
-const LOGGING_TAG_MAX_LEN: usize = 128;
+// Maximum length of a tag that does not require allocation.
+const LOGGING_TAG_MAX_LEN: usize = 127;
 const LOGGING_MSG_MAX_LEN: usize = 4000;
 
 impl Default for AndroidLogger {
@@ -211,7 +212,7 @@ impl Log for AndroidLogger {
             return;
         }
 
-        // tag must not exceed LOGGING_TAG_MAX_LEN
+        // tag longer than LOGGING_TAG_MAX_LEN causes allocation
         let mut tag_bytes: [MaybeUninit<u8>; LOGGING_TAG_MAX_LEN + 1] = uninit_array();
 
         let module_path = record.module_path().unwrap_or_default().to_owned();


### PR DESCRIPTION
The currently hard-coded limit is 23 characters. This limit originates from the pre-Android 7.0 32-character limit on system property names, because Android's `liblog` allows setting the log level at runtime through `log.tag` system properties [1]. The limit meant that "log.tag.SOMETAG" must have been shorter than 32 bytes, leaving 23 bytes for the tag itself.

The system property length limitation was removed in [2], so since 2017 it no longer applies, and some Android components already use longer tags [3][4].

This change increases the size of the stack-allocated buffer used for null-terminating the tag to 128 bytes, and adds support for even longer tags by falling back to heap-allocated CString when the tag is longer than that. The fallback path will introduce a performance penalty, but at the same time will allow manual level adjustment via log.tag. system property regardless of the tag length.

[1] https://cs.android.com/android/platform/superproject/main/+/main:system/logging/logd/README.property;l=50?q=f:readme.property
[2] https://android-review.googlesource.com/c/platform/bionic/+/327226
[3] https://cs.android.com/android/platform/superproject/main/+/main:device/generic/goldfish-opengl/system/codecs/omx/plugin/GoldfishVideoDecoderOMXComponent.cpp;l=20
[4] https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/biometrics/fingerprint/2.2/default/BiometricsFingerprint.cpp;l=16