### PR TITLE
Use __android_log_is_loggable in AndroidLogger::enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
           - armv7-linux-androideabi
           - aarch64-linux-android
           - i686-linux-android
+        features:
+          - ""
+          - --no-default-features
+          - --all-features
 
     steps:
       - uses: actions/checkout@v3
@@ -37,9 +41,9 @@ jobs:
           components: rustfmt, clippy
 
       - run: cargo fmt --check
-      - run: cargo clippy --target=${{ matrix.target }} -- -Dwarnings
-      - run: cargo build --target=${{ matrix.target }}
-      - run: cargo doc --target=${{ matrix.target }}
+      - run: cargo clippy --target=${{ matrix.target }} ${{ matrix.features }} -- -Dwarnings
+      - run: cargo build --target=${{ matrix.target }} ${{ matrix.features }}
+      - run: cargo doc --target=${{ matrix.target }} ${{ matrix.features }}
         env:
           RUSTDOCFLAGS: -Dwarnings
       # Temporary test non-target only.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,13 @@ targets = [
 [features]
 default = ["regex"]
 regex = ["env_filter/regex"]
+android-api-30 = []
 
 [dependencies.log]
 version = "0.4"
 
 [dependencies.android_log-sys]
-version = "0.3"
+version = "0.3.2"
 
 [dependencies.env_filter]
 version = "0.1"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,48 @@ Therefore this library will only log a warning for subsequent `init_once` calls.
 This library ensures that logged messages do not overflow Android log message limits
 by efficiently splitting messages into chunks.
 
+## Consistent log filtering in mixed Rust/C/C++ apps
+
+Android's C logging API determines the effective log level based on [a
+combination](https://cs.android.com/android/platform/superproject/main/+/main:system/logging/liblog/properties.cpp;l=243;drc=b74a506c1b69f5b295a8cdfd7e2da3b16db15934),
+of a process-wide global variable, [system-wide
+properties](https://cs.android.com/android/platform/superproject/main/+/main:system/logging/logd/README.property;l=45;drc=99c545d3098018a544cb292e1501daca694bee0f),
+and call-specific default. `log` + `android_logger` crates add another layer of
+log filtering on top of that, independent from the C API.
+
+```
+    .-----.
+    | app |
+    '-----'     Rust
+C/C++ | '--------------.
+      |                v
+      |          .-----------.   filter by log::STATIC_MAX_LEVEL +
+      |          | log crate | - log::MAX_LOG_LEVEL_FILTER,
+      |          '-----------'   overrideable via log::set_max_level
+      |                |
+      |                v
+      |     .----------------------.
+      |     | android_logger crate | - filter by Config::max_level
+      |     '----------------------'
+      |                |
+      |   .------------'
+      v   v
+   .--------.
+   | liblog | - filter by global state or system-wide properties
+   '--------'
+```
+
+`liblog` APIs introduced in Android API 30 let `android_logger` delegate log
+filtering decision to `liblog`, making the log level consistent across C, C++
+and Rust calls.
+
+If you build `android_logger` with `android-api-30` feature enabled, the logger
+will consider the process-wide global state (set via
+[`__android_log_set_minimum_priority`](https://cs.android.com/android/platform/superproject/main/+/main:prebuilts/runtime/mainline/runtime/sdk/common_os/include/system/logging/liblog/include/android/log.h;l=364;drc=4cf460634134d51dba174f8af60dffb10f703f51)
+and Android system properties when deciding if a message should be logged or
+not. In this case, the effective log level is the _least verbose_ of the levels
+set between those and Rust log facilities.
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ by efficiently splitting messages into chunks.
 ## Consistent log filtering in mixed Rust/C/C++ apps
 
 Android's C logging API determines the effective log level based on [a
-combination](https://cs.android.com/android/platform/superproject/main/+/main:system/logging/liblog/properties.cpp;l=243;drc=b74a506c1b69f5b295a8cdfd7e2da3b16db15934),
+combination](https://cs.android.com/android/platform/superproject/main/+/main:system/logging/liblog/properties.cpp;l=243;drc=b74a506c1b69f5b295a8cdfd7e2da3b16db15934)
 of a process-wide global variable, [system-wide
 properties](https://cs.android.com/android/platform/superproject/main/+/main:system/logging/logd/README.property;l=45;drc=99c545d3098018a544cb292e1501daca694bee0f),
 and call-specific default. `log` + `android_logger` crates add another layer of
@@ -102,7 +102,7 @@ and Rust calls.
 
 If you build `android_logger` with `android-api-30` feature enabled, the logger
 will consider the process-wide global state (set via
-[`__android_log_set_minimum_priority`](https://cs.android.com/android/platform/superproject/main/+/main:prebuilts/runtime/mainline/runtime/sdk/common_os/include/system/logging/liblog/include/android/log.h;l=364;drc=4cf460634134d51dba174f8af60dffb10f703f51)
+[`__android_log_set_minimum_priority`](https://cs.android.com/android/platform/superproject/main/+/main:prebuilts/runtime/mainline/runtime/sdk/common_os/include/system/logging/liblog/include/android/log.h;l=364;drc=4cf460634134d51dba174f8af60dffb10f703f51))
 and Android system properties when deciding if a message should be logged or
 not. In this case, the effective log level is the _least verbose_ of the levels
 set between those and Rust log facilities.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,8 @@ const LOGGING_MSG_MAX_LEN: usize = 4000;
 
 impl Log for AndroidLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
-        self.config().is_loggable(metadata.level())
+        self.config()
+            .is_loggable(metadata.target(), metadata.level())
     }
 
     fn log(&self, record: &Record) {

--- a/src/platform_log_writer.rs
+++ b/src/platform_log_writer.rs
@@ -1,5 +1,5 @@
 use crate::arrays::slice_assume_init_ref;
-use crate::{LOGGING_MSG_MAX_LEN, LogId, android_log, uninit_array};
+use crate::{android_log, uninit_array, LogId, LOGGING_MSG_MAX_LEN};
 use log::Level;
 #[cfg(target_os = "android")]
 use log_ffi::LogPriority;
@@ -153,7 +153,11 @@ impl fmt::Write for PlatformLogWriter<'_> {
                 .enumerate()
                 .fold(None, |acc, (i, (output, input))| {
                     output.write(*input);
-                    if *input == b'\n' { Some(i) } else { acc }
+                    if *input == b'\n' {
+                        Some(i)
+                    } else {
+                        acc
+                    }
                 });
 
             // update last \n index

--- a/src/platform_log_writer.rs
+++ b/src/platform_log_writer.rs
@@ -1,5 +1,5 @@
 use crate::arrays::slice_assume_init_ref;
-use crate::{android_log, uninit_array, LogId, LOGGING_MSG_MAX_LEN};
+use crate::{LOGGING_MSG_MAX_LEN, LogId, android_log, uninit_array};
 use log::Level;
 #[cfg(target_os = "android")]
 use log_ffi::LogPriority;
@@ -153,11 +153,7 @@ impl fmt::Write for PlatformLogWriter<'_> {
                 .enumerate()
                 .fold(None, |acc, (i, (output, input))| {
                     output.write(*input);
-                    if *input == b'\n' {
-                        Some(i)
-                    } else {
-                        acc
-                    }
+                    if *input == b'\n' { Some(i) } else { acc }
                 });
 
             // update last \n index


### PR DESCRIPTION
Android's C logging API determines the effective log level based on a combination [1] of a global variable, system-wide properties [2], and call-specific default. log + android_logger crates add another layer of log filtering on top of that, independent from the C API.

```
        .-----.
        | app |
        '-----'
           |
           v
     .-----------.   filter by STATIC_MAX_LEVEL [3] +
     | log crate | - MAX_LOG_LEVEL_FILTER [4],
     '-----------'   overrideable via log::set_max_level
           |
           v
.----------------------.
| android_logger crate | - filter by Config::max_level [5]
'----------------------'
           |
           v
       .--------.
       | liblog | - filter by global state or system-wide properties [2]
       '--------'
```

The result is that in mixed C/C++ + Rust applications, logs originating from Rust use the least verbose level configured, which sometimes results in unexpected loss of logs.

In addition, adjusting the log level globally via system properties, very useful in work on the AOSP itself, currently works only up to the level android_logger defaults to.

This change makes AndroidLogger completely delegate log filtering to the underlying liblog when Config::max_level is unset by using __android_log_is_loggable.

Setting Config::max_level, or calling log::set_max_level still keep the existing behavior of filtering the logs before they reach liblog, but the default is now to have the log level consistent between Rust and C/C++ logs.

It also removes one TODO from the code :)

Tested by:
- running a test app that uses Rust logs of all levels on a rooted device, using both Android's liblog C API and android_logger ones
- adjusting the log.tag system property [2] via adb shell setprop
- verifying the message filtering changes according to log.tag changes consistently for logs from both languages

This PR depends on bindings being added in https://github.com/rust-mobile/android_log-sys-rs/pull/6

[1] https://cs.android.com/android/platform/superproject/main/+/main:system/logging/liblog/properties.cpp;l=243;drc=b74a506c1b69f5b295a8cdfd7e2da3b16db15934
[2] https://cs.android.com/android/platform/superproject/main/+/main:system/logging/logd/README.property;l=45;drc=99c545d3098018a544cb292e1501daca694bee0f
[3] https://github.com/rust-lang/log/blob/0551261bb4588b7f8afc8be05640347c97b67e10/src/lib.rs#L1536
[4] https://github.com/rust-lang/log/blob/0551261bb4588b7f8afc8be05640347c97b67e10/src/lib.rs#L469
[5] https://github.com/rust-mobile/android_logger-rs/blob/d51b7ffdacf20fb09fd36a6b309b50240ef50728/src/lib.rs#L198