### PR TITLE
ci: Run `cargo fmt --check` to ensure code is always properly formatted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
+          components: rustfmt
 
+      - run: cargo fmt --check
       - run: cargo build --target=${{ matrix.target }}
       - run: cargo doc --target=${{ matrix.target }}
       # Temporary test non-target only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,14 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
-          components: rustfmt
+          components: rustfmt, clippy
 
       - run: cargo fmt --check
+      - run: cargo clippy --target=${{ matrix.target }} -- -Dwarnings
       - run: cargo build --target=${{ matrix.target }}
       - run: cargo doc --target=${{ matrix.target }}
+        env:
+          RUSTDOCFLAGS: -Dwarnings
       # Temporary test non-target only.
       # TODO: Test in emulator or something.
       - run: cargo test

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,10 +20,13 @@ impl fmt::Debug for Config {
             .field("buf_id", &self.buf_id)
             .field("filter", &self.filter)
             .field("tag", &self.tag)
-            .field("custom_format", match &self.custom_format {
-                Some(_) => &"Some(_)",
-                None => &"None",
-            })
+            .field(
+                "custom_format",
+                match &self.custom_format {
+                    Some(_) => &"Some(_)",
+                    None => &"None",
+                },
+            )
             .finish()
     }
 }


### PR DESCRIPTION
Note that the `style_format` setting in `rustfmt.toml` would default to `edition` in `Cargo.toml`, but that's still on `2021` while `2024` already generates a bit nicer formatted code so this file is left in place.
