### PR TITLE
Remove `max_level` in favour of extracting it from the `Filter`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           components: rustfmt, clippy
 
       - run: cargo fmt --check
+      - run: cargo clippy --target=${{ matrix.target }} ${{ matrix.features }} -- -Dwarnings
       - run: cargo build --target=${{ matrix.target }} ${{ matrix.features }}
       - run: cargo doc --target=${{ matrix.target }} ${{ matrix.features }}
         env:

--- a/examples/system_log_level_overrides.rs
+++ b/examples/system_log_level_overrides.rs
@@ -68,16 +68,16 @@
 //! ```
 
 fn main() {
+    todo!("This test and its comments are no longer true after with_max_level is removed");
     android_logger::init_once(
-        android_logger::Config::default()
-            .with_tag("log_test")
-            // If set, this is the highest level to log unless overriddeby by the system.
-            // Note the verbosity can be *increased* through system properties.
-            .with_max_level(log::LevelFilter::Info),
+        android_logger::Config::default().with_tag("log_test"),
+        // If set, this is the highest level to log unless overridden by by the system.
+        // Note the verbosity can be *increased* through system properties.
+        // .with_max_level(log::LevelFilter::Info),
     );
     // The log crate applies its filtering before we even get to android_logger.
     // Pass everything down so that Android's liblog can determine the log level instead.
-    log::set_max_level(log::LevelFilter::Trace);
+    // log::set_max_level(log::LevelFilter::Trace);
 
     log::trace!("trace");
     log::debug!("debug");

--- a/src/platform_log_writer.rs
+++ b/src/platform_log_writer.rs
@@ -192,12 +192,11 @@ pub mod tests {
     use crate::arrays::slice_assume_init_ref;
     use crate::platform_log_writer::PlatformLogWriter;
     use log::Level;
-    use std::ffi::CStr;
     use std::fmt::Write;
 
     #[test]
     fn platform_log_writer_init_values() {
-        let tag = CStr::from_bytes_with_nul(b"tag\0").unwrap();
+        let tag = c"tag";
 
         let writer = PlatformLogWriter::new(None, Level::Warn, tag);
 
@@ -318,10 +317,6 @@ pub mod tests {
     }
 
     fn get_tag_writer() -> PlatformLogWriter<'static> {
-        PlatformLogWriter::new(
-            None,
-            Level::Warn,
-            CStr::from_bytes_with_nul(b"tag\0").unwrap(),
-        )
+        PlatformLogWriter::new(None, Level::Warn, c"tag")
     }
 }

--- a/tests/config_log_level.rs
+++ b/tests/config_log_level.rs
@@ -1,10 +1,14 @@
-extern crate android_logger;
-extern crate log;
+use android_logger::FilterBuilder;
+use log::LevelFilter;
 
 #[test]
 fn config_log_level() {
     android_logger::init_once(
-        android_logger::Config::default().with_max_level(log::LevelFilter::Trace),
+        android_logger::Config::default().with_filter(
+            FilterBuilder::new()
+                .filter_level(LevelFilter::Trace)
+                .build(),
+        ),
     );
 
     assert_eq!(log::max_level(), log::LevelFilter::Trace);

--- a/tests/default_init.rs
+++ b/tests/default_init.rs
@@ -1,10 +1,8 @@
-extern crate android_logger;
-extern crate log;
-
 #[test]
 fn default_init() {
     android_logger::init_once(Default::default());
 
-    // android_logger has default log level "off"
-    assert_eq!(log::max_level(), log::LevelFilter::Off);
+    // android_logger has default log level of Error
+    // TODO: env_logger/env_filter have this too, but I cannot find it in the source code
+    assert_eq!(log::max_level(), log::LevelFilter::Error);
 }

--- a/tests/multiple_init.rs
+++ b/tests/multiple_init.rs
@@ -1,16 +1,24 @@
-extern crate android_logger;
-extern crate log;
+use android_logger::FilterBuilder;
+use log::LevelFilter;
 
 #[test]
 fn multiple_init() {
     android_logger::init_once(
-        android_logger::Config::default().with_max_level(log::LevelFilter::Trace),
+        android_logger::Config::default().with_filter(
+            FilterBuilder::new()
+                .filter_level(LevelFilter::Trace)
+                .build(),
+        ),
     );
 
     // Second initialization should be silently ignored
     android_logger::init_once(
-        android_logger::Config::default().with_max_level(log::LevelFilter::Error),
+        android_logger::Config::default().with_filter(
+            FilterBuilder::new()
+                .filter_level(LevelFilter::Error)
+                .build(),
+        ),
     );
 
-    assert_eq!(log::max_level(), log::LevelFilter::Trace);
+    assert_eq!(log::max_level(), LevelFilter::Trace);
 }


### PR DESCRIPTION
Fixes #80

Documentation for `log` specifies that all implementations must have a way to initialize `log::set_max_level()` (because it otherwise defaults to `Off`), in our case via the `with_max_level()` builder - and by calling `init_once()`.  Over time `android_logger` received `env_filter` support for much more fine-grained control over filtering, making `android_logger` similar to `env_logger` in its implementation.

With this change however, ambiguity arises when independently configuring log levels through `.with_max_level()` and `env_filter::Filter`.  The former acts as an early performance save directly in `log::log!()` macros while the latter applies additional filtering inside `android_logger`.  In short: `log::max_level()` must be at least as high as what `Filter` can process, otherwise messages get lost before they reach the `Filter`.

`env_logger` solved this ambiguity by hiding direct access to `log::set_max_level()` as an implementation detail and initializing it to the highest level that could possibly be processed by the `Filter`. Mimick this inside `android_logger` by removing the `with_max_level()` setter.  In addition all internal `is_enabled()` filtering and related tests are removed because we rely on the `log` macros themselves to filter, and no longer track `max_level` inside.  Keeping in mind that any user can techincally change `log::set_max_level()` to increase or decrease global verbosity.

The only complexity remains around `__android_log_is_loggable_len()` on Android 30 and above (if enabled on the crate by the user - not necessarily based on the actual minimum nor target SDK level yet!) which asks the Android system for `env_filter`-like per-module (tag) level overrides.

## TODO

- Make `env_filter` non-`Option`al?
  - Forward its `Builder`-constructors like `filter_level()` and `filter_module()`, just like `env_logger`.
  - Also create various constructors based on `env_logger`/`env_filter`'s environment variables?  These are less common to be set for Android apps.
  - Revisit the correct default. `Error` makes sense here.
- Revise tests around level filters, which are now no longer implemented on the `AndroidLogger` level.
- Update README and crate-documentation samples to match the new API (once finalized).
  - Insert a test / build step that includes the `README` in these tests, either:
    1. `#![doc = include_str!("README.md")]`;
    2. https://crates.io/crates/cargo-readme.
